### PR TITLE
CYOA: Fix home page and add GitHub Actions deployment for worker (closes #55)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,28 @@
+name: Deploy CYOA Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/choose-your-own-adventure/worker/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: apps/choose-your-own-adventure/worker
+        run: npm install
+
+      - name: Deploy to Cloudflare Workers
+        working-directory: apps/choose-your-own-adventure/worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/choose-your-own-adventure/src/main.ts
+++ b/apps/choose-your-own-adventure/src/main.ts
@@ -41,8 +41,8 @@ class App {
   private async handleRoute(): Promise<void> {
     const hash = window.location.hash.slice(1);
 
-    // Home page or no hash
-    if (!hash || hash === 'home') {
+    // Home page: empty hash, '/', or 'home'
+    if (!hash || hash === '' || hash === 'home') {
       await this.showHomePage();
       return;
     }
@@ -76,12 +76,9 @@ class App {
       return;
     }
 
-    // Legacy format - just node ID, use default story
-    if (hash && this.currentStoryId === null) {
-      this.currentStoryId = DEFAULT_STORY;
-      this.currentNodeId = hash;
-      await this.loadStory(DEFAULT_STORY);
-    }
+    // If we get here with a hash, show home page (removed legacy format that auto-loads default story)
+    // This prevents unintended redirects to the default story
+    await this.showHomePage();
   }
 
   private async showHomePage(): Promise<void> {


### PR DESCRIPTION
Implementation for issue #55

## Problems

1. **Root URL shows dragon story instead of home page** - `/` should show story selection, not redirect to `#start`
2. **Worker changes not auto-deployed** - Worker code changes merged but not deployed to Cloudflare

## Required Fixes

### 1. Fix Home Page Routing

The app should show story selection when:
- URL is `/` (no hash)
- URL is `#home`
- URL is empty

Currently something is causing it to go to `#start` which loads dragon-adventure directly.

Check `src/main.ts` init logic - ensure empty hash shows home page, not default story.

### 2. Add GitHub Actions for Worker Deployment

Create `.github/workflows/deploy-worker.yml`:

```yaml
name: Deploy CYOA Worker

on:
  push:
    branches: [main]
    paths:
      - 'apps/choose-your-own-adventure/worker/**'

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      
      - name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: '20'
          
      - name: Install dependencies
        working-directory: apps/choose-your-own-adventure/worker
        run: npm install
        
      - name: Deploy to Cloudflare Workers
        working-directory: apps/choose-your-own-adventure/worker
        run: npx wrangler deploy
        env:
          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
```

Need to add `CLOUDFLARE_API_TOKEN` to repository secrets.

### 3. Deploy Worker Now

After fixing, manually deploy:
```bash
cd apps/choose-your-own-adventure/worker
wrangler deploy
```

## Acceptance Criteria

- [ ] `https://dragon-adventure.pages.dev/` shows story selection with 3 stories
- [ ] GitHub Actions auto-deploys worker on push to main
- [ ] `/api/stories` endpoint returns list of stories
- [ ] All existing story functionality preserved

Closes #55

---
_Created by worker agent_