### PR TITLE
CYOA: Fix home page routing and redeploy worker (closes #54)

### DIFF
--- a/apps/choose-your-own-adventure/src/main.ts
+++ b/apps/choose-your-own-adventure/src/main.ts
@@ -5,7 +5,6 @@
 import './styles/main.css';
 import { api, type StoryNode, type StoryData } from './api/client';
 
-const DEFAULT_STORY = 'dragon-adventure';
 const SAVE_KEY_PREFIX = 'cyoa-save-';
 
 interface SaveData {
@@ -76,12 +75,8 @@ class App {
       return;
     }
 
-    // Legacy format - just node ID, use default story
-    if (hash && this.currentStoryId === null) {
-      this.currentStoryId = DEFAULT_STORY;
-      this.currentNodeId = hash;
-      await this.loadStory(DEFAULT_STORY);
-    }
+    // Invalid hash format - redirect to home
+    window.location.hash = 'home';
   }
 
   private async showHomePage(): Promise<void> {


### PR DESCRIPTION
Implementation for issue #54

## Problem

1. **Root URL redirects to #start** - Going to `/` redirects to `#start` which loads dragon-adventure directly instead of showing story selection
2. **Worker not redeployed** - `/api/stories` endpoint returns 404 because worker wasn't redeployed after adding the endpoint

## Root Cause

The frontend `index.html` or some initialization code is adding `#start` to the URL on load, bypassing the home page logic.

## Required Fixes

### 1. Fix index.html / initial routing
- Remove any redirect to `#start` 
- Empty hash or `/` should show home page (story selection)
- `#home` should also show home page

### 2. Redeploy worker
```bash
cd apps/choose-your-own-adventure/worker
wrangler deploy
```

### 3. Test the full flow
- `/` shows story selection with dragon-adventure, space-odyssey, haunted-mansion
- Clicking a story goes to `#storyId/start`
- `/api/stories` returns list of stories

## Acceptance Criteria

- [ ] `https://dragon-adventure.pages.dev/` shows story selection (not dragon story)
- [ ] `/api/stories` endpoint returns list of available stories
- [ ] All three stories appear on home page
- [ ] Clicking a story starts that specific story

Closes #54

---
_Created by worker agent_