### PR TITLE
CYOA: Add GitHub Actions deployment for Cloudflare Pages frontend (closes #62)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,36 @@
+name: Deploy CYOA Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/choose-your-own-adventure/src/**'
+      - 'apps/choose-your-own-adventure/index.html'
+      - 'apps/choose-your-own-adventure/package.json'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: apps/choose-your-own-adventure
+        run: npm install
+
+      - name: Build
+        working-directory: apps/choose-your-own-adventure
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: dragon-adventure
+          directory: apps/choose-your-own-adventure/dist


### PR DESCRIPTION
Implementation for issue #62

## URGENT: Frontend not deploying

The frontend at https://dragon-adventure.pages.dev is NOT being rebuilt when code is pushed. The deployed JS doesn't have `getStories` or home page functionality.

**Root cause**: No GitHub Action to build and deploy the frontend to Cloudflare Pages.

## Solution

Create `.github/workflows/deploy-pages.yml`:

```yaml
name: Deploy CYOA Frontend

on:
  push:
    branches: [main]
    paths:
      - 'apps/choose-your-own-adventure/src/**'
      - 'apps/choose-your-own-adventure/index.html'
      - 'apps/choose-your-own-adventure/package.json'

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      
      - name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: '20'
          
      - name: Install dependencies
        working-directory: apps/choose-your-own-adventure
        run: npm install
        
      - name: Build
        working-directory: apps/choose-your-own-adventure
        run: npm run build
        
      - name: Deploy to Cloudflare Pages
        uses: cloudflare/pages-action@v1
        with:
          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
          projectName: dragon-adventure
          directory: apps/choose-your-own-adventure/dist
```

## Required Secrets

Add to repository secrets:
- `CLOUDFLARE_API_TOKEN` - API token with Pages edit permission
- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare account ID

## Acceptance Criteria

- [ ] Workflow file created
- [ ] Frontend auto-deploys on push to main
- [ ] Home page shows story list at https://dragon-adventure.pages.dev/
- [ ] `/api/stories` data displays correctly

Closes #62

---
_Created by worker agent_