### PR TITLE
CYOA: Add manual trigger to deploy-pages workflow and trigger initial deploy (closes #64)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/choose-your-own-adventure/src/**'
       - 'apps/choose-your-own-adventure/index.html'
       - 'apps/choose-your-own-adventure/package.json'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Implementation for issue #64

## URGENT

The deploy-pages.yml workflow only triggers on frontend file changes. Need to:

1. Add `workflow_dispatch` trigger so it can be run manually
2. Trigger the workflow to deploy current code

## Fix

Update `.github/workflows/deploy-pages.yml`:

```yaml
on:
  push:
    branches: [main]
    paths:
      - 'apps/choose-your-own-adventure/src/**'
      - 'apps/choose-your-own-adventure/index.html'
      - 'apps/choose-your-own-adventure/package.json'
  workflow_dispatch:  # ADD THIS LINE
```

## Acceptance Criteria

- [ ] Workflow has workflow_dispatch trigger
- [ ] Workflow runs after merge
- [ ] https://dragon-adventure.pages.dev/ shows story selection

Closes #64

---
_Created by worker agent_