### PR TITLE
CYOA: Fix TypeScript error - remove unused DEFAULT_STORY constant (closes #66)

### DIFF
--- a/apps/choose-your-own-adventure/src/main.ts
+++ b/apps/choose-your-own-adventure/src/main.ts
@@ -5,7 +5,6 @@
 import './styles/main.css';
 import { api, type StoryNode, type StoryData } from './api/client';
 
-const DEFAULT_STORY = 'dragon-adventure';
 const SAVE_KEY_PREFIX = 'cyoa-save-';
 
 interface SaveData {


### PR DESCRIPTION
Implementation for issue #66

## URGENT - Blocking deployment

Build fails with:
```
src/main.ts(8,7): error TS6133: 'DEFAULT_STORY' is declared but its value is never read.
```

## Fix

In `apps/choose-your-own-adventure/src/main.ts`, remove the unused `DEFAULT_STORY` constant on line 8.

## Acceptance Criteria

- [ ] Build passes (`npm run build`)
- [ ] Deploy workflow succeeds
- [ ] https://dragon-adventure.pages.dev/ shows story selection

Closes #66

---
_Created by worker agent_